### PR TITLE
Allow installing deprecated `sklearn`

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -20,6 +20,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: python -m pip install --upgrade pip
     - name: Install dependencies
+      env:
+        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
       run: |
         pip install poetry
         poetry install


### PR DESCRIPTION
## Overview

This PR adds an environment variable to CI when installing Python packages.

## Context

I got the following error on CI.

```
ChefBuildError

  Backend subprocess exited when trying to invoke get_requires_for_build_wheel
  
  The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
  rather than 'sklearn' for pip commands. 
  
  Here is how to fix this error in the main use cases:
  - use 'pip install scikit-learn' rather than 'pip install sklearn'
  - replace 'sklearn' by 'scikit-learn' in your pip requirements files
    (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
  - if the 'sklearn' package is used by one of your dependencies,
    it would be great if you take some time to track which package uses
    'sklearn' instead of 'scikit-learn' and report it to their issue tracker
  - as a last resort, set the environment variable
    SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
  
  More information is available at
  https://github.com/scikit-learn/sklearn-pypi-package
  
  If the previous advice does not cover your use case, feel free to report it at
  https://github.com/scikit-learn/sklearn-pypi-package/issues/new
  

  at /opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/poetry/installation/chef.py:152 in _prepare
      148│ 
      149│                 error = ChefBuildError("\n\n".join(message_parts))
      150│ 
      151│             if error is not None:
    → 152│                 raise error from None
      153│ 
      154│             return path
      155│ 
      156│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:

Note: This error originates from the build backend, and is likely not a problem with poetry but with sklearn (0.0.post1) not supporting PEP 517 builds. You can verify this by running 'pip wheel --use-pep517 "sklearn (==0.0.post1)"'.
```

https://github.com/rejasupotaro/amazon-product-search/actions/runs/4641978666/jobs/8215507126#step:5:394

It appears that one of the packages uses the deprecated `sklearn` instead of `sckit-learn`. Ideally, I should send a PR, but as a temporary solution, I will allow installation of the deprecated package.