### PR TITLE
Introduce Eland

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -688,7 +688,7 @@ test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 name = "contourpy"
 version = "1.0.6"
 description = "Python library for calculating contours of 2D quadrilateral grids"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -902,7 +902,7 @@ test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0
 name = "cycler"
 version = "0.11.0"
 description = "Composable style cycles"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1008,6 +1008,31 @@ python-versions = "*"
 files = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
+
+[[package]]
+name = "eland"
+version = "8.7.0"
+description = "Python Client and Toolkit for DataFrames, Big Data, Machine Learning and ETL in Elasticsearch"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "eland-8.7.0-py3-none-any.whl", hash = "sha256:55f5203ffbcc24be4fcb212c4cec2dca3f8c642f5aa2dc5e03ed8e2cc0f2fd88"},
+    {file = "eland-8.7.0.tar.gz", hash = "sha256:33401274cbe1f2bd1a2823d7949d8a84d2fa7373462308ed6b2041c028090406"},
+]
+
+[package.dependencies]
+elasticsearch = ">=8.3,<9"
+matplotlib = ">=3.6"
+numpy = "<2"
+pandas = ">=1.5"
+
+[package.extras]
+all = ["lightgbm (>=2,<4)", "scikit-learn (>=0.22.1,<2)", "sentence-transformers (>=2.1.0,<=2.2.2)", "torch (>=1.11.0,<1.12.0)", "transformers[torch] (>=4.12.0,<=4.20.1)", "xgboost (>=0.90,<2)"]
+lightgbm = ["lightgbm (>=2,<4)"]
+pytorch = ["sentence-transformers (>=2.1.0,<=2.2.2)", "torch (>=1.11.0,<1.12.0)", "transformers[torch] (>=4.12.0,<=4.20.1)"]
+scikit-learn = ["scikit-learn (>=0.22.1,<2)"]
+xgboost = ["xgboost (>=0.90,<2)"]
 
 [[package]]
 name = "elastic-transport"
@@ -1190,7 +1215,7 @@ pyflakes = ">=2.5.0,<2.6.0"
 name = "fonttools"
 version = "4.38.0"
 description = "Tools to manipulate font files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2098,7 +2123,7 @@ use = ["tensorflow", "tensorflow_hub", "tensorflow_text"]
 name = "kiwisolver"
 version = "1.4.4"
 description = "A fast implementation of the Cassowary constraint solver"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2262,7 +2287,7 @@ files = [
 name = "matplotlib"
 version = "3.6.2"
 description = "Python plotting package"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -5515,4 +5540,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.10.8"
-content-hash = "9fa74d3ef1110162725163263e18b8552b896b29a548abbcc4d3a60c1e6fb47b"
+content-hash = "c9bd7e3923150ee967e0ee99278fa6077f61981f15123537f6134ac9ee2374dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ unidic-lite = "^1.0.8"
 polars = {version = "^0.16.0", extras = ["numpy", "pandas", "pyarrow"]}
 types-requests = "^2.28.11.17"
 docker = "^6.0.1"
+eland = "8.7.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2"

--- a/src/amazon_product_search/es/es_client.py
+++ b/src/amazon_product_search/es/es_client.py
@@ -75,6 +75,7 @@ class EsClient:
 
         ptm = PyTorchModel(self.es, tm.elasticsearch_model_id())
         ptm.import_model(model_path=model_path, config_path=None, vocab_path=vocab_path, config=config)
+        ptm.start()
 
     def count_docs(self, index_name: str) -> int:
         return self.es.count(index=index_name)["count"]

--- a/src/amazon_product_search/es/es_client.py
+++ b/src/amazon_product_search/es/es_client.py
@@ -1,8 +1,12 @@
 import json
+from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
 
+from eland.ml.pytorch import PyTorchModel
+from eland.ml.pytorch.transformers import TransformerModel
 from elasticsearch import Elasticsearch, helpers
 
+from amazon_product_search.constants import MODELS_DIR
 from amazon_product_search.es.response import Response, Result
 
 
@@ -28,6 +32,49 @@ class EsClient:
             schema = json.load(file)
             print(schema)
         self.es.indices.create(index=index_name, mappings=schema["mappings"])
+
+    def import_model(self, model_id: str, tmp_path: str = MODELS_DIR):
+        """Import a TransformerModel into Elasticsearch.
+
+        Call `POST _ml/trained_models/_model_id_/deployment/_start` after the model is imported.
+        The imported model can be used as follows:
+        ```
+        GET products_jp/_search
+        {
+          "query": {
+            "match": {
+              "product_title": {
+                "query": "東京"
+              }
+            }
+          },
+          "knn": [
+            {
+              "field": "product_vector",
+              "k": 10,
+              "num_candidates": "100",
+              "query_vector_builder": {
+                "text_embedding": {
+                  "model_id": "sonoisa__sentence-bert-base-ja-mean-tokens-v2",
+                  "model_text": "東京"
+                }
+              }
+            }
+          ]
+        }
+        ```
+
+        Args:
+            model_id (str): The name of the transformer model to import.
+            tmp_path (str, optional): The directory to save the model. Defaults to MODELS_DIR.
+        """
+        tm = TransformerModel(model_id, task_type="text_embedding")
+
+        Path(tmp_path).mkdir(parents=True, exist_ok=True)
+        model_path, config, vocab_path = tm.save(tmp_path)
+
+        ptm = PyTorchModel(self.es, tm.elasticsearch_model_id())
+        ptm.import_model(model_path=model_path, config_path=None, vocab_path=vocab_path, config=config)
 
     def count_docs(self, index_name: str) -> int:
         return self.es.count(index=index_name)["count"]

--- a/tasks/es_tasks.py
+++ b/tasks/es_tasks.py
@@ -1,6 +1,6 @@
 from invoke import task
 
-from amazon_product_search.constants import PROJECT_ID, PROJECT_NAME, REGION
+from amazon_product_search.constants import HF, PROJECT_ID, PROJECT_NAME, REGION
 from amazon_product_search.es.es_client import EsClient
 
 
@@ -23,6 +23,12 @@ def recreate_index(c, index_name):
     es_client = EsClient()
     es_client.delete_index(index_name=index_name)
     es_client.create_index(index_name=index_name)
+
+
+@task
+def import_model(c):
+    es_client = EsClient()
+    es_client.import_model(model_id=HF.JA_SBERT)
 
 
 @task


### PR DESCRIPTION
## Summary

This PR enables the import of encoders into Elasticsearch via [eland](https://github.com/elastic/eland).

## Eland DataFrame

By using eland, it is possible to analyze indexed docs with the APIs that are compatible with Pandas. It appears that eland interprets pandas APIs into Elasticsearch APIs as implemented [here](https://github.com/elastic/eland/blob/main/eland/query_compiler.py).

Since eland retrieved data from Elasticsearch, any excluded columns are not retrieved. In this project, the field `product_vector` is defined as an excluded field (`mappings._source.excludes: "product_vector"`), which results in the values being NaN, as shown below.

```python
>>> import eland as ed
>>> df = ed.DataFrame("http://localhost:9200", es_index_pattern="products_jp")
>>> df
                      product_brand  ... product_vector
B07R91TVJB                           ...            NaN
B00FW60P84                           ...            NaN
B071KNF11Z                   SHD-PB  ...            NaN
B07HR6BC88                           ...            NaN
B089Q21H6Z                    Meize  ...            NaN
...                             ...  ...            ...
B078GHPC9T  ティーケーカンパニー (TK.Company)  ...            NaN
B07KYY329D        TRAVELIST(トラベリスト)  ...            NaN
B07T15VXM2                           ...            NaN
B07YD6R7M3                   KIZUNA  ...            NaN
B083JF93J5                  Tbmodel  ...            NaN

[100 rows x 10 columns]
```

## Machine Learning with Eland

Another notable feature of Eland is that it allows the execution ML models within Elastisearch ([Machine Learning | Eland Python Client | Elastic](https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html)).

### Encoding Text at Query Time

As of Elasticsearch 8.7, encoders can be executed at query time. To achieve this, a model must first be imported into Elasticsearch. I have added a task for importing models, which uses eland.

```
$ poetry run inv es.import-model
$ curl -X POST http://localhost:9200/_ml/trained_models/sonoisa__sentence-bert-base-ja-mean-tokens-v2/deployment/_start
```

This is equivalent to the below command.

```shell
$ eland_import_hub_model \
  --url http://localhost:9200 \
  --hub-model-id sonoisa/sentence-bert-base-ja-mean-tokens-v2 \
  --task-type text_embedding \
  --start
```

<details>

<summary>AuthorizationException: current license is non-compliant for [ml]</summary>

I got this error when I tried to import a model. It turns out that using Pytorch models is a platinum-licensed feature.

```shell
$ poetry run inv es.import-model
Traceback (most recent call last):
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/bin/inv", line 8, in <module>
    sys.exit(program.run())
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/invoke/program.py", line 384, in run
    self.execute()
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/invoke/program.py", line 569, in execute
    executor.execute(*self.tasks)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/invoke/executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/invoke/tasks.py", line 127, in __call__
    result = self.body(*args, **kwargs)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/tasks/es_tasks.py", line 50, in import_model
    ptm.import_model(model_path=model_path, config_path=None, vocab_path=vocab_path, config=config)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/eland/ml/pytorch/_pytorch_model.py", line 122, in import_model
    self.put_config(path=config_path, config=config)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/eland/ml/pytorch/_pytorch_model.py", line 78, in put_config
    self._client.ml.put_trained_model(model_id=self.model_id, **config_map)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/elasticsearch/_sync/client/utils.py", line 414, in wrapped
    return api(*args, **kwargs)
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/elasticsearch/_sync/client/ml.py", line 3301, in put_trained_model
    return self.perform_request(  # type: ignore[return-value]
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/elasticsearch/_sync/client/_base.py", line 389, in perform_request
    return self._client.perform_request(
  File "/Users/kentaro-takiguchi/projects/amazon-product-search/.venv/lib/python3.10/site-packages/elasticsearch/_sync/client/_base.py", line 320, in perform_request
    raise HTTP_EXCEPTIONS.get(meta.status, ApiError)(
elasticsearch.AuthorizationException: AuthorizationException(403, 'security_exception', 'current license is non-compliant for [ml]')
```

I started the trial by calling the following API.

```
$ curl -X POST http://localhost:9200/_license/start_trial?acknowledge=true
```

It costs $125 per month ([Official Elasticsearch Pricing: Elastic Cloud, Managed Elasticsearch | Elastic](https://www.elastic.co/pricing/)).

</details>

#### Testing

Index docs:

```shell
$ poetry run inv es.index \
  --index-name=products_jp \
  --locale=jp \
  --dest-host=http://localhost:9200 \
  --extract-keywords \
  --encode-text \
  --nrows=100
```

Retrieve docs using the imported model:

```python
GET products_jp/_search
{
  "query": {
    "match": {
      "product_title": {
        "query": "東京"
      }
    }
  },
  "knn": [
    {
      "field": "product_vector",
      "k": 10,
      "num_candidates": "100",
      "query_vector_builder": {
        "text_embedding": {
          "model_id": "sonoisa__sentence-bert-base-ja-mean-tokens-v2",
          "model_text": "東京"
        }
      }
    }
  ]
}
```

## References

- [Natural language processing | Machine Learning in the Elastic Stack [8.7] | Elastic](https://www.elastic.co/guide/en/machine-learning/current/ml-nlp.html)
  - [How to deploy a text embedding model and use it for semantic search | Machine Learning in the Elastic Stack [8.7] | Elastic](https://www.elastic.co/guide/en/machine-learning/current/ml-nlp-text-emb-vector-search-example.html)
- [How to deploy NLP: Text Embeddings and Vector Search | Elastic Blog](https://www.elastic.co/blog/how-to-deploy-nlp-text-embeddings-and-vector-search)