### PR TITLE
Query type experiment

### DIFF
--- a/src/amazon_product_search/es/query_builder.py
+++ b/src/amazon_product_search/es/query_builder.py
@@ -61,7 +61,7 @@ class QueryBuilder:
             }
         }
 
-    def build_knn_search_query(self, query: str, field: str, top_k: int) -> dict[str, Any]:
+    def build_dense_search_query(self, query: str, field: str, top_k: int) -> dict[str, Any]:
         """Build a KNN ES query from given conditions.
 
         Args:

--- a/src/amazon_product_search/es/query_builder.py
+++ b/src/amazon_product_search/es/query_builder.py
@@ -1,7 +1,6 @@
 from typing import Any
 
-from amazon_product_search.constants import DATA_DIR
-from amazon_product_search.constants import HF
+from amazon_product_search.constants import DATA_DIR, HF
 from amazon_product_search.synonyms.synonym_dict import SynonymDict
 from amazon_product_search_dense_retrieval.encoders import Encoder, SBERTEncoder
 

--- a/src/amazon_product_search/es/query_builder.py
+++ b/src/amazon_product_search/es/query_builder.py
@@ -10,7 +10,7 @@ class QueryBuilder:
         self.synonym_dict = SynonymDict(data_dir)
         self.encoder: Encoder = SBERTEncoder(HF.JP_SBERT)
 
-    def _multi_match(self, query: str, fields: list[str], match_type: str = "cross_fields") -> dict[str, Any]:
+    def _multi_match(self, query: str, fields: list[str], match_type: str) -> dict[str, Any]:
         return {
             "multi_match": {
                 "query": query,
@@ -40,8 +40,10 @@ class QueryBuilder:
 
     def _build_sparse_search_query(self, query_type: str, query: str, fields: list[str]) -> dict[str, Any]:
         match query_type:
-            case "multi_match":
-                return self._multi_match(query, fields)
+            case "cross_fields":
+                return self._multi_match(query, fields, match_type="cross_fields")
+            case "best_fields":
+                return self._multi_match(query, fields, match_type="best_fields")
             case "combined_fields":
                 return self._combined_fields(query, fields)
             case "simple_query_string":
@@ -52,7 +54,7 @@ class QueryBuilder:
     def build_sparse_search_query(
         self, query: str,
         fields: list[str],
-        query_type: str = "multi_match",
+        query_type: str = "cross_fields",
         is_synonym_expansion_enabled: bool = False,
     ) -> dict[str, Any]:
         """Build a multi-match ES query.

--- a/src/amazon_product_search/es/query_builder.py
+++ b/src/amazon_product_search/es/query_builder.py
@@ -10,7 +10,7 @@ class QueryBuilder:
         self.synonym_dict = SynonymDict()
         self.encoder: Encoder = SBERTEncoder(HF.JP_SBERT)
 
-    def build_multimatch_search_query(
+    def build_sparse_search_query(
         self, query: str, fields: list[str], is_synonym_expansion_enabled: bool = False
     ) -> dict[str, Any]:
         """Build a multi-match ES query.

--- a/src/amazon_product_search/es/query_builder.py
+++ b/src/amazon_product_search/es/query_builder.py
@@ -47,7 +47,7 @@ class QueryBuilder:
             case "simple_query_string":
                 return self._simple_query_string(query, fields)
             case _:
-                raise ValueError(f"Unkknown query_type is given: {query_type}")
+                raise ValueError(f"Unknown query_type is given: {query_type}")
 
     def build_sparse_search_query(
         self, query: str,

--- a/src/amazon_product_search/es/query_builder.py
+++ b/src/amazon_product_search/es/query_builder.py
@@ -41,9 +41,9 @@ class QueryBuilder:
     def _build_sparse_search_query(self, query_type: str, query: str, fields: list[str]) -> dict[str, Any]:
         match query_type:
             case "cross_fields":
-                return self._multi_match(query, fields, match_type="cross_fields")
+                return self._multi_match(query, fields, query_type="cross_fields")
             case "best_fields":
-                return self._multi_match(query, fields, match_type="best_fields")
+                return self._multi_match(query, fields, query_type="best_fields")
             case "combined_fields":
                 return self._combined_fields(query, fields)
             case "simple_query_string":

--- a/src/amazon_product_search/es/query_builder.py
+++ b/src/amazon_product_search/es/query_builder.py
@@ -1,13 +1,14 @@
 from typing import Any
 
+from amazon_product_search.constants import DATA_DIR
 from amazon_product_search.constants import HF
 from amazon_product_search.synonyms.synonym_dict import SynonymDict
 from amazon_product_search_dense_retrieval.encoders import Encoder, SBERTEncoder
 
 
 class QueryBuilder:
-    def __init__(self):
-        self.synonym_dict = SynonymDict()
+    def __init__(self, data_dir: str = DATA_DIR):
+        self.synonym_dict = SynonymDict(data_dir)
         self.encoder: Encoder = SBERTEncoder(HF.JP_SBERT)
 
     def _multi_match(self, query: str, fields: list[str], match_type: str = "cross_fields") -> dict[str, Any]:

--- a/src/amazon_product_search/es/query_builder.py
+++ b/src/amazon_product_search/es/query_builder.py
@@ -10,11 +10,11 @@ class QueryBuilder:
         self.synonym_dict = SynonymDict(data_dir)
         self.encoder: Encoder = SBERTEncoder(HF.JP_SBERT)
 
-    def _multi_match(self, query: str, fields: list[str], match_type: str) -> dict[str, Any]:
+    def _multi_match(self, query: str, fields: list[str], query_type: str) -> dict[str, Any]:
         return {
             "multi_match": {
                 "query": query,
-                "type": match_type,
+                "type": query_type,
                 "fields": fields,
                 "operator": "and",
             }
@@ -54,7 +54,7 @@ class QueryBuilder:
     def build_sparse_search_query(
         self, query: str,
         fields: list[str],
-        query_type: str = "cross_fields",
+        query_type: str = "combined_fields",
         is_synonym_expansion_enabled: bool = False,
     ) -> dict[str, Any]:
         """Build a multi-match ES query.

--- a/src/amazon_product_search/synonyms/synonym_dict.py
+++ b/src/amazon_product_search/synonyms/synonym_dict.py
@@ -7,21 +7,22 @@ from amazon_product_search.nlp.tokenizer import Tokenizer
 
 
 class SynonymDict:
-    def __init__(self, synonym_filename: str = "synonyms_jp_sbert.csv"):
+    def __init__(self, data_dir: str = DATA_DIR, synonym_filename: str = "synonyms_jp_sbert.csv"):
         self.tokenizer = Tokenizer()
-        self._entry_dict: dict[str, list[tuple[str, float]]] = self.load_synonym_dict(synonym_filename)
+        self._entry_dict: dict[str, list[tuple[str, float]]] = self.load_synonym_dict(data_dir, synonym_filename)
 
     @staticmethod
-    def load_synonym_dict(synonym_filename: str) -> dict[str, list[tuple[str, float]]]:
+    def load_synonym_dict(data_dir: str, synonym_filename: str) -> dict[str, list[tuple[str, float]]]:
         """Load the synonym file and convert it into a dict for lookup.
 
         Args:
-        synonym_filename (str): A filename to load, which is supposed to be under `{DATA_DIR}/includes`.
+            data_dir (str): The data directory.
+            synonym_filename (str): A filename to load, which is supposed to be under `{DATA_DIR}/includes`.
 
         Returns:
             dict[str, list[str]]: The converted synonym dict.
         """
-        df = pl.read_csv(f"{DATA_DIR}/includes/{synonym_filename}")
+        df = pl.read_csv(f"{data_dir}/includes/{synonym_filename}")
         entry_dict = defaultdict(list)
         for row in df.to_dicts():
             query = row["query"]

--- a/src/demo/apps/search/experimental_setup.py
+++ b/src/demo/apps/search/experimental_setup.py
@@ -16,6 +16,7 @@ from amazon_product_search.source import Locale
 class Variant:
     name: str
     fields: list[str] = field(default_factory=lambda: ["product_title"])
+    query_type: str = "combined_fields"
     enable_synonym_expansion: bool = False
     top_k: int = 100
     reranker: Reranker = field(default_factory=lambda: NoOpReranker())
@@ -30,6 +31,17 @@ class ExperimentalSetup:
 
 
 EXPERIMENTS = {
+    "query_types": ExperimentalSetup(
+        index_name="products_jp",
+        locale="jp",
+        num_queries=100,
+        variants=[
+            Variant(name="best_fields", query_type="best_fields"),
+            Variant(name="cross_fields", query_type="cross_fields"),
+            Variant(name="combined_fields", query_type="combined_fields"),
+            Variant(name="simple_query_string", query_type="simple_query_string"),
+        ],
+    ),
     "different_fields": ExperimentalSetup(
         index_name="products_jp",
         locale="jp",

--- a/src/demo/apps/search/experimental_setup.py
+++ b/src/demo/apps/search/experimental_setup.py
@@ -11,6 +11,8 @@ from amazon_product_search.reranking.reranker import (
 )
 from amazon_product_search.source import Locale
 
+ALL_FIELDS = ["product_title", "product_brand", "product_color", "product_bullet_point", "product_description"]
+
 
 @dataclass
 class Variant:
@@ -36,10 +38,10 @@ EXPERIMENTS = {
         locale="jp",
         num_queries=100,
         variants=[
-            Variant(name="best_fields", query_type="best_fields"),
-            Variant(name="cross_fields", query_type="cross_fields"),
-            Variant(name="combined_fields", query_type="combined_fields"),
-            Variant(name="simple_query_string", query_type="simple_query_string"),
+            Variant(name="best_fields", fields=ALL_FIELDS, query_type="best_fields"),
+            Variant(name="cross_fields", fields=ALL_FIELDS, query_type="cross_fields"),
+            Variant(name="combined_fields", fields=ALL_FIELDS, query_type="combined_fields"),
+            Variant(name="simple_query_string", fields=ALL_FIELDS, query_type="simple_query_string"),
         ],
     ),
     "different_fields": ExperimentalSetup(

--- a/src/demo/apps/search/pages/7_🔍_Search.py
+++ b/src/demo/apps/search/pages/7_🔍_Search.py
@@ -95,7 +95,7 @@ def main():
 
         query_type = st.selectbox(
             "Query Type:",
-            options=["cross_fields", "best_fields", "combined_fields", "simple_query_string"],
+            options=["combined_fields", "cross_fields", "best_fields", "simple_query_string"],
         )
 
         is_synonym_expansion_enabled = st.checkbox("enable_synonym_expansion")

--- a/src/demo/apps/search/pages/7_🔍_Search.py
+++ b/src/demo/apps/search/pages/7_🔍_Search.py
@@ -64,6 +64,11 @@ def main():
         )
         sparse_fields, dense_fields = split_fields(selected_fields)
 
+        query_type = st.selectbox(
+            "Query Type:",
+            options=["multi_match", "combined_fields", "simple_query_string"],
+        )
+
         is_synonym_expansion_enabled = st.checkbox("enable_synonym_expansion")
 
         reranker = from_string(st.selectbox("reranker:", ["NoOpReranker", "RandomReranker", "DotReranker"]))
@@ -73,6 +78,7 @@ def main():
             es_query = query_builder.build_sparse_search_query(
                 query=normalized_query,
                 fields=sparse_fields,
+                query_type=query_type,
                 is_synonym_expansion_enabled=is_synonym_expansion_enabled,
             )
         es_knn_query = None

--- a/src/demo/apps/search/pages/7_🔍_Search.py
+++ b/src/demo/apps/search/pages/7_🔍_Search.py
@@ -81,7 +81,7 @@ def main():
         query = st.text_input("Query:")
         normalized_query = normalize_query(query)
 
-        selected_fields = st.multiselect(
+        fields = st.multiselect(
             "Fields:",
             options=[
                 "product_title",
@@ -93,7 +93,13 @@ def main():
             ],
             default=["product_title"],
         )
-        sparse_fields, dense_fields = split_fields(selected_fields)
+        sparse_fields, dense_fields = split_fields(fields)
+
+        columns = st.columns(2)
+        with columns[0]:
+            sparse_boost = st.number_input("Sparse Boost", value=1.0)
+        with columns[1]:
+            dense_boost = st.number_input("Dense Boost", value=1.0)
 
         query_type = st.selectbox(
             "Query Type:",
@@ -110,12 +116,15 @@ def main():
                 query=normalized_query,
                 fields=sparse_fields,
                 query_type=query_type,
+                boost=sparse_boost,
                 is_synonym_expansion_enabled=is_synonym_expansion_enabled,
             )
         es_knn_query = None
         if normalized_query and dense_fields:
             # TODO: Should multiple vector fields be handled?
-            es_knn_query = query_builder.build_dense_search_query(normalized_query, field=dense_fields[0], top_k=size)
+            es_knn_query = query_builder.build_dense_search_query(
+                normalized_query, field=dense_fields[0], top_k=size, boost=dense_boost,
+            )
 
         if not st.form_submit_button("Search"):
             return

--- a/src/demo/apps/search/pages/7_🔍_Search.py
+++ b/src/demo/apps/search/pages/7_🔍_Search.py
@@ -78,7 +78,7 @@ def main():
         es_knn_query = None
         if normalized_query and dense_fields:
             # TODO: Should multiple vector fields be handled?
-            es_knn_query = query_builder.build_knn_search_query(normalized_query, field=dense_fields[0], top_k=size)
+            es_knn_query = query_builder.build_dense_search_query(normalized_query, field=dense_fields[0], top_k=size)
 
         if not st.form_submit_button("Search"):
             return

--- a/src/demo/apps/search/pages/7_🔍_Search.py
+++ b/src/demo/apps/search/pages/7_🔍_Search.py
@@ -50,6 +50,8 @@ def draw_response_stats(response: Response):
         if dense_score:
             row["sparse_score"] = sparse_score
             row["dense_score"] = dense_score
+        else:
+            row["sparse_score"] = row["total_score"]
         rows.append(row)
 
     df = pd.DataFrame(rows)

--- a/src/demo/apps/search/pages/7_🔍_Search.py
+++ b/src/demo/apps/search/pages/7_🔍_Search.py
@@ -95,7 +95,7 @@ def main():
 
         query_type = st.selectbox(
             "Query Type:",
-            options=["multi_match", "combined_fields", "simple_query_string"],
+            options=["cross_fields", "best_fields", "combined_fields", "simple_query_string"],
         )
 
         is_synonym_expansion_enabled = st.checkbox("enable_synonym_expansion")

--- a/src/demo/apps/search/pages/7_🔍_Search.py
+++ b/src/demo/apps/search/pages/7_🔍_Search.py
@@ -37,12 +37,19 @@ def draw_response_stats(response: Response):
 
         explanation = result.explanation
         row["total_score"] = explanation["value"]
+        sparse_score = 0
+        dense_score = None
         if explanation["description"] == "sum of:":
             for child_explanation in explanation["details"]:
                 if child_explanation["description"] == "within top k documents":
-                    row["dense_score"] = child_explanation["value"]
+                    if not dense_score:
+                        dense_score = 0
+                    dense_score += child_explanation["value"]
                 else:
-                    row["sparse_score"] = child_explanation["value"]
+                    sparse_score += child_explanation["value"]
+        if dense_score:
+            row["sparse_score"] = sparse_score
+            row["dense_score"] = dense_score
         rows.append(row)
 
     df = pd.DataFrame(rows)

--- a/src/demo/apps/search/pages/7_🔍_Search.py
+++ b/src/demo/apps/search/pages/7_🔍_Search.py
@@ -70,7 +70,7 @@ def main():
 
         es_query = None
         if sparse_fields:
-            es_query = query_builder.build_multimatch_search_query(
+            es_query = query_builder.build_sparse_search_query(
                 query=normalized_query,
                 fields=sparse_fields,
                 is_synonym_expansion_enabled=is_synonym_expansion_enabled,

--- a/src/demo/apps/search/pages/8_🔍_Experiments.py
+++ b/src/demo/apps/search/pages/8_🔍_Experiments.py
@@ -55,7 +55,10 @@ def search(index_name: str, query: str, variant: Variant) -> Response:
     sparse_fields, dense_fields = utils.split_fields(variant.fields)
     if sparse_fields:
         es_query = query_builder.build_sparse_search_query(
-            query=query, fields=sparse_fields, is_synonym_expansion_enabled=variant.enable_synonym_expansion
+            query=query,
+            fields=sparse_fields,
+            query_type=variant.query_type,
+            is_synonym_expansion_enabled=variant.enable_synonym_expansion,
         )
     if dense_fields:
         # TODO: Should multiple vector fields be handled?
@@ -156,11 +159,11 @@ def main():
 
     st.write("#### Metrics by query")
     with st.expander("click to expand"):
-        st.write(metrics_df)
+        st.write(metrics_df.to_pandas())
 
     st.write("#### Metrics by variant")
     stats_df = compute_stats(metrics_df)
-    st.write(stats_df)
+    st.write(stats_df.to_pandas())
 
     st.write("#### Analysis")
     draw_figures(metrics_df)

--- a/src/demo/apps/search/pages/8_🔍_Experiments.py
+++ b/src/demo/apps/search/pages/8_🔍_Experiments.py
@@ -59,7 +59,7 @@ def search(index_name: str, query: str, variant: Variant) -> Response:
         )
     if dense_fields:
         # TODO: Should multiple vector fields be handled?
-        es_knn_query = query_builder.build_knn_search_query(query, dense_fields[0], top_k=variant.top_k)
+        es_knn_query = query_builder.build_dense_search_query(query, dense_fields[0], top_k=variant.top_k)
 
     return es_client.search(index_name=index_name, query=es_query, knn_query=es_knn_query, size=variant.top_k)
 

--- a/src/demo/apps/search/pages/8_🔍_Experiments.py
+++ b/src/demo/apps/search/pages/8_🔍_Experiments.py
@@ -54,7 +54,7 @@ def search(index_name: str, query: str, variant: Variant) -> Response:
 
     sparse_fields, dense_fields = utils.split_fields(variant.fields)
     if sparse_fields:
-        es_query = query_builder.build_multimatch_search_query(
+        es_query = query_builder.build_sparse_search_query(
             query=query, fields=sparse_fields, is_synonym_expansion_enabled=variant.enable_synonym_expansion
         )
     if dense_fields:

--- a/tests/unit/amazon_product_search/es/test_query_builder.py
+++ b/tests/unit/amazon_product_search/es/test_query_builder.py
@@ -5,7 +5,7 @@ from amazon_product_search.es.query_builder import QueryBuilder
 
 def test_build_search_query():
     query_builder = QueryBuilder()
-    es_query = query_builder.build_multimatch_search_query(query="query", fields=["product_title"])
+    es_query = query_builder.build_sparse_search_query(query="query", fields=["product_title"])
     assert es_query == {
         "multi_match": {
             "query": "query",
@@ -21,7 +21,7 @@ def test_build_search_query_with_synonym_expansion_enabled(mock_method):
     mock_method.return_value = {"query": [("synonym", 1.0), ("antonym", 0.1)]}
 
     query_builder = QueryBuilder()
-    es_query = query_builder.build_multimatch_search_query(
+    es_query = query_builder.build_sparse_search_query(
         query="query", fields=["product_title"], is_synonym_expansion_enabled=True
     )
     assert es_query == {

--- a/tests/unit/amazon_product_search/es/test_query_builder.py
+++ b/tests/unit/amazon_product_search/es/test_query_builder.py
@@ -13,6 +13,7 @@ def test_build_search_query():
             "query": "query",
             "fields": ["product_title"],
             "operator": "and",
+            "boost": 1.0,
         }
     }
 
@@ -33,6 +34,7 @@ def test_build_search_query_with_synonym_expansion_enabled(mock_method):
                         "query": "query",
                         "fields": ["product_title"],
                         "operator": "and",
+                        "boost": 1.0,
                     },
                 },
                 {
@@ -40,6 +42,7 @@ def test_build_search_query_with_synonym_expansion_enabled(mock_method):
                         "query": "synonym",
                         "fields": ["product_title"],
                         "operator": "and",
+                        "boost": 1.0,
                     },
                 },
             ],
@@ -51,4 +54,4 @@ def test_build_search_query_with_synonym_expansion_enabled(mock_method):
 def test_build_knn_search_query():
     query_builder = QueryBuilder()
     es_query = query_builder.build_dense_search_query(query="query", field="product_vector", top_k=10)
-    assert es_query.keys() == {"query_vector", "field", "k", "num_candidates"}
+    assert es_query.keys() == {"query_vector", "field", "k", "num_candidates", "boost"}

--- a/tests/unit/amazon_product_search/es/test_query_builder.py
+++ b/tests/unit/amazon_product_search/es/test_query_builder.py
@@ -5,11 +5,12 @@ from amazon_product_search.es.query_builder import QueryBuilder
 
 def test_build_search_query():
     query_builder = QueryBuilder()
-    es_query = query_builder.build_sparse_search_query(query="query", fields=["product_title"])
+    es_query = query_builder.build_sparse_search_query(
+        query="query", fields=["product_title"], query_type="combined_fields"
+    )
     assert es_query == {
-        "multi_match": {
+        "combined_fields": {
             "query": "query",
-            "type": "cross_fields",
             "fields": ["product_title"],
             "operator": "and",
         }
@@ -22,23 +23,21 @@ def test_build_search_query_with_synonym_expansion_enabled(mock_method):
 
     query_builder = QueryBuilder()
     es_query = query_builder.build_sparse_search_query(
-        query="query", fields=["product_title"], is_synonym_expansion_enabled=True
+        query="query", fields=["product_title"], query_type="combined_fields", is_synonym_expansion_enabled=True
     )
     assert es_query == {
         "bool": {
             "should": [
                 {
-                    "multi_match": {
+                    "combined_fields": {
                         "query": "query",
-                        "type": "cross_fields",
                         "fields": ["product_title"],
                         "operator": "and",
                     },
                 },
                 {
-                    "multi_match": {
+                    "combined_fields": {
                         "query": "synonym",
-                        "type": "cross_fields",
                         "fields": ["product_title"],
                         "operator": "and",
                     },

--- a/tests/unit/amazon_product_search/es/test_query_builder.py
+++ b/tests/unit/amazon_product_search/es/test_query_builder.py
@@ -51,5 +51,5 @@ def test_build_search_query_with_synonym_expansion_enabled(mock_method):
 
 def test_build_knn_search_query():
     query_builder = QueryBuilder()
-    es_query = query_builder.build_knn_search_query(query="query", field="product_vector", top_k=10)
+    es_query = query_builder.build_dense_search_query(query="query", field="product_vector", top_k=10)
     assert es_query.keys() == {"query_vector", "field", "k", "num_candidates"}


### PR DESCRIPTION
## Summary

This PR is to experiment with different query types.

- `combined_fields` is now the default query type.
- The distribution of scores varies depending on the type of query and the fields involved.
  - Since the total score consists of `match_score` and `knn_score` like `score = 0.9 * match_score + 0.1 * knn_score`, it's difficult to choose the boost of `knn_score` 😕 


## Queries

- [`multi_match, best_fields`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-best-fields)
- [`multi_match, cross_fields`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#type-cross-fields)
- [`combined_fields`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-combined-fields-query.html)
- [`simple_query_string`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html)

### Match Type

Roughly speaking, there are two types of matching methods. Given the query "nike black",

#### All terms must be present in a single field

```
  (+product_title:nike +product_title:black)
| (+product_brand:nike  +product_brand:black)
| ...
```

`best_fields` and `simple_query_string` are in this category.

#### All terms must be present in at least one field

```
+(product_title:nike product_brand:nike ...)
+(product_title:black product_brand:black ...)
```

`cross_fields` and `combined_fields` are in this category.

## Results

The experiments were conducted on the index with 339,059 products. The queries were sampled from the test dataset.

### Metrics

variant | total_hits | zero_hit_rate | recall | ndcg | ndcg_prime
-- | -- | -- | -- | -- | --
best_fields | 559 | 0.35 | 0.3051 | 0.7412 | 0.9421
combined_fields | 621 | 0.29 | 0.3117 | 0.7484 | 0.9412
cross_fields | 621 | 0.29 | 0.3032 | 0.7598 | 0.9582
simple_query_string | 585 | 0.3 | 0.3033 | 0.7165 | 0.9437

### Score Distribution by `query_type`

| query_type          |   total_hits |   highest_score@100 |   lowest_score@100 |
|:--------------------|-------------:|--------------------:|-------------------:|
| best_fields         |      419.984 |             25.5379 |            14.9563 |
| combined_fields     |      486.985 |             27.8789 |            18.141  |
| cross_fields        |      486.985 |             22.5231 |            14.5114 |
| simple_query_string |      433.848 |             47.0538 |            18.5859 |

![](https://github.com/rejasupotaro/amazon-product-search/assets/883148/371d97eb-3594-4241-abea-c485ed129748)

### Score Distribution by `field`

| fields                                                                             |   total_hits |   highest_score@100 |   lowest_score@100 |
|:-----------------------------------------------------------------------------------|-------------:|--------------------:|-------------------:|
| product_title                                                                      |      67.0893 |             26.2831 |            19.3504 |
| product_title,product_brand                                                        |      63.2787 |             26.784  |            20.0833 |
| product_title,product_brand,product_color                                          |      61.619  |             26.3941 |            19.7399 |
| product_title,product_brand,product_color,product_bullet_point                     |     307.03   |             27.0323 |            18.1482 |
| product_title,product_brand,product_color,product_bullet_point,product_description |     486.985  |             27.8789 |            18.141  |

![](https://github.com/rejasupotaro/amazon-product-search/assets/883148/3ccfddaf-d2ae-41ef-bfa2-fee8a6fadc5f)