### PR TITLE
Reorganize search engine configuration files

### DIFF
--- a/search_engines/elasticsearch/Dockerfile
+++ b/search_engines/elasticsearch/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.17.3
+
+# Install the Elasticsearch plugin
+RUN ./bin/elasticsearch-plugin install --batch https://github.com/o19s/elasticsearch-learning-to-rank/releases/download/v1.5.10-es8.17.3/ltr-plugin-v1.5.10-es8.17.3.zip

--- a/search_engines/elasticsearch/compose.yaml
+++ b/search_engines/elasticsearch/compose.yaml
@@ -1,0 +1,25 @@
+services:
+  es-8:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.16.2
+    container_name: amazon-product-search-es8
+    environment:
+      - xpack.security.enabled=false
+      - discovery.type=single-node
+    ports:
+      - 9200:9200
+    volumes:
+      - es-data:/usr/share/elasticsearch/8/data
+
+  kibana-8:
+    depends_on:
+      - es-8
+    image: docker.elastic.co/kibana/kibana:8.16.2
+    container_name: amazon-product-search-kibana8
+    ports:
+      - 5602:5601
+    environment:
+      - ELASTICSEARCH_HOSTS=http://es-8:9200
+
+volumes:
+  es-data:
+    driver: local

--- a/search_engines/elasticsearch/compose.yaml
+++ b/search_engines/elasticsearch/compose.yaml
@@ -1,6 +1,8 @@
 services:
   es-8:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.16.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.3
+    build:
+      context: .
     container_name: amazon-product-search-es8
     environment:
       - xpack.security.enabled=false
@@ -13,7 +15,7 @@ services:
   kibana-8:
     depends_on:
       - es-8
-    image: docker.elastic.co/kibana/kibana:8.16.2
+    image: docker.elastic.co/kibana/kibana:8.17.3
     container_name: amazon-product-search-kibana8
     ports:
       - 5602:5601

--- a/search_engines/vespa/compose.yaml
+++ b/search_engines/vespa/compose.yaml
@@ -1,29 +1,4 @@
 services:
-  es-8:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.16.2
-    container_name: amazon-product-search-es8
-    environment:
-      - xpack.security.enabled=false
-      - discovery.type=single-node
-    ports:
-      - 9200:9200
-    volumes:
-      - es-data:/usr/share/elasticsearch/8/data
-    profiles:
-      - elasticsearch
-
-  kibana-8:
-    depends_on:
-      - es-8
-    image: docker.elastic.co/kibana/kibana:8.16.2
-    container_name: amazon-product-search-kibana8
-    ports:
-      - 5602:5601
-    environment:
-      - ELASTICSEARCH_HOSTS=http://es-8:9200
-    profiles:
-      - elasticsearch
-
   # https://docs.vespa.ai/en/operations-selfhosted/multinode-systems.html
   # https://docs.vespa.ai/en/operations-selfhosted/files-processes-and-ports.html
   vespa-0:
@@ -47,8 +22,6 @@ services:
       - vespa-data-0:/opt/vespa/var
     environment:
       VESPA_CONFIGSERVERS: amazon-product-search-vespa-0.vespanet
-    profiles:
-      - vespa
 
   vespa-1:
     image: vespaengine/vespa:8.301.19
@@ -68,12 +41,8 @@ services:
       - vespa-data-1:/opt/vespa/var
     environment:
       VESPA_CONFIGSERVERS: amazon-product-search-vespa-0.vespanet
-    profiles:
-      - vespa
 
 volumes:
-  es-data:
-    driver: local
   vespa-data-0:
     driver: local
   vespa-data-1:


### PR DESCRIPTION
This pull request includes significant updates to the Elasticsearch and Vespa configurations. The most important changes include upgrading the Elasticsearch version, adding a new Dockerfile for Elasticsearch, and restructuring the Docker Compose configurations for both Elasticsearch and Vespa.

### Elasticsearch updates:
* [`search_engines/elasticsearch/Dockerfile`](diffhunk://#diff-936d3992b0655cfd299b94eb0439d6be85f9ee7dfa17cbe21270a3341d1b2308R1-R4): Added a new Dockerfile to install Elasticsearch version 8.17.3 and the learning-to-rank plugin.
* [`search_engines/elasticsearch/compose.yaml`](diffhunk://#diff-e9afc431844f608eaa571a99a26e9e56531de82cc88f84336d8efb0c43dff1d5R1-R27): Created a new Docker Compose file to configure Elasticsearch and Kibana services with version 8.17.3.

### Vespa updates:
* [`search_engines/vespa/compose.yaml`](diffhunk://#diff-0d1d16229b2018fee6477bbfb18c001f217aaee5b9256bf07cabd40f3462d2d0L2-L26): Removed Elasticsearch and Kibana services from the Vespa Compose file and renamed the file from `compose.yaml`.
* [`search_engines/vespa/compose.yaml`](diffhunk://#diff-0d1d16229b2018fee6477bbfb18c001f217aaee5b9256bf07cabd40f3462d2d0L50-L51): Removed the `vespa` profile from the Vespa services configuration. [[1]](diffhunk://#diff-0d1d16229b2018fee6477bbfb18c001f217aaee5b9256bf07cabd40f3462d2d0L50-L51) [[2]](diffhunk://#diff-0d1d16229b2018fee6477bbfb18c001f217aaee5b9256bf07cabd40f3462d2d0L71-L76)
* [`search_engines/vespa/compose.yaml`](diffhunk://#diff-0d1d16229b2018fee6477bbfb18c001f217aaee5b9256bf07cabd40f3462d2d0L71-L76): Removed the `es-data` volume configuration.