### PR TITLE
Add benchmark task

### DIFF
--- a/src/model-serving/Makefile
+++ b/src/model-serving/Makefile
@@ -1,3 +1,18 @@
 .PHONY: export
 export:
 	poetry run python src/model_serving/cli.py
+
+.PHONY: benchmark
+benchmark:
+	@if [ ! -f /tmp/open_inference_grpc.proto ]; then \
+		echo "Downloading proto file to /tmp directory..."; \
+		curl -sSf -o /tmp/open_inference_grpc.proto https://raw.githubusercontent.com/kserve/open-inference-protocol/main/specification/protocol/open_inference_grpc.proto; \
+	fi
+	@ghz \
+		--proto=/tmp/open_inference_grpc.proto \
+		--call=inference.GRPCInferenceService.ModelInfer \
+		--data '{"model_name": "ensemble", "inputs": [{"name": "text", "datatype": "BYTES", "shape": [1], "contents": {"bytes_contents": ["aGVsbG8gd29ybGQ="]}}]}' \
+		--total=100 \
+		--concurrency=2 \
+		--insecure \
+		localhost:8001

--- a/src/model-serving/README.md
+++ b/src/model-serving/README.md
@@ -81,6 +81,46 @@ $ curl -X POST http://localhost:8000/v2/models/ensemble/infer \
 }'
 ```
 
+## Benchmark
+
+You can benchmark the Triton server using the `make benchmark`:
+
+```
+$ make benchmark
+Summary:
+  Count:	100
+  Total:	1.89 s
+  Slowest:	75.24 ms
+  Fastest:	34.75 ms
+  Average:	37.29 ms
+  Requests/sec:	52.90
+
+Response time histogram:
+  34.751 [1]  |
+  38.800 [93] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
+  42.850 [3]  |∎
+  46.899 [1]  |
+  50.948 [1]  |
+  54.998 [0]  |
+  59.047 [0]  |
+  63.097 [0]  |
+  67.146 [0]  |
+  71.195 [0]  |
+  75.245 [1]  |
+
+Latency distribution:
+  10 % in 35.70 ms
+  25 % in 35.99 ms
+  50 % in 36.31 ms
+  75 % in 37.07 ms
+  90 % in 37.93 ms
+  95 % in 40.71 ms
+  99 % in 49.94 ms
+
+Status code distribution:
+  [OK]   100 responses
+```
+
 ## Host on Vertex AI
 
 [Serving Predictions with NVIDIA Triton  |  Vertex AI  |  Google Cloud](https://cloud.google.com/vertex-ai/docs/predictions/using-nvidia-triton)


### PR DESCRIPTION
This pull request introduces a new benchmarking feature to the model-serving component. The most important changes include adding a benchmark target to the `Makefile` and updating the `README.md` to document the new benchmarking capability.

Benchmarking feature:

* [`src/model-serving/Makefile`](diffhunk://#diff-df8f69673233edb36e1a5598a5dcc9f5b50e9e1cc06816aafe7f93426fc69a7fR4-R18): Added a new `benchmark` target to download the necessary proto file and run performance benchmarks using `ghz`.
* [`src/model-serving/README.md`](diffhunk://#diff-bbcda248b8baaec893a15f82dbc64a264f4ccb0b37c113a98b80a279e3c64499R84-R123): Updated to include instructions and output examples for running the new `make benchmark` command.